### PR TITLE
feat: option to switch between standard and custom server

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,4 +17,5 @@ target 'Susi' do
   pod 'SwiftLint'
   pod 'Nuke-Gifu-Plugin'
   pod 'BouncyLayout'
+  pod 'DLRadioButton', '~> 1.4'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,6 +3,7 @@ PODS:
   - AlamofireImage (3.2.0):
     - Alamofire (~> 4.1)
   - BouncyLayout (1.1.0)
+  - DLRadioButton (1.4.9)
   - Gifu (2.0.0)
   - Material (2.6.3):
     - Material/Core (= 2.6.3)
@@ -23,6 +24,7 @@ DEPENDENCIES:
   - Alamofire (~> 4.4)
   - AlamofireImage (~> 3.1)
   - BouncyLayout
+  - DLRadioButton (~> 1.4)
   - Material
   - Nuke-Gifu-Plugin
   - Popover
@@ -36,6 +38,7 @@ SPEC CHECKSUMS:
   Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
   AlamofireImage: 157ed682cc81d3b9db4fb90c1f12180ac552d93b
   BouncyLayout: f91c6504437a61acd733404f55f75bd8154f5840
+  DLRadioButton: 7bb8a6e3768b572469ace553391ab4d2af6f9c19
   Gifu: 56a4d8f1092399159fa32662aa2232158b48d8ac
   Material: af607a7ec0e9978ef85cf189a3d8ceeeb650400f
   Nuke: 8ab71e77f6a54ff5fb697f93537c35f419bb01f7
@@ -47,6 +50,6 @@ SPEC CHECKSUMS:
   SwiftValidators: 4ccbec749f61a36f7a922781bb09452e80cde396
   Toast-Swift: 5b2f8f720f7e78e48511f693df1f9c9a6e38a25a
 
-PODFILE CHECKSUM: bcbe5e19baf27d0e1e3a6998864e1a936c20c4cc
+PODFILE CHECKSUM: 2deec0c56c7791e4f58c4e067c3ce9e74d89a6bc
 
 COCOAPODS: 1.2.1

--- a/Susi/Controllers/ForgotPasswordController/ForgotPasswordVCMethods.swift
+++ b/Susi/Controllers/ForgotPasswordController/ForgotPasswordVCMethods.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import DLRadioButton
 
 extension ForgotPasswordViewController {
 
@@ -33,6 +34,57 @@ extension ForgotPasswordViewController {
             .top(UIView.UIMarginSpec.largeMatgin)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+    }
+
+    func prepareRadioButtons() {
+        self.view.addSubview(standardServerRB)
+        self.view.layout(standardServerRB)
+            .top(emailField.frame.maxY + UIView.UIMarginSpec.mediumMargin)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
+        self.view.layoutSubviews()
+        standardServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.view.addSubview(customServerRB)
+        self.view.layout(customServerRB)
+            .top(standardServerRB.frame.maxY)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+        customServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.view.addSubview(self.customServerAddressField)
+        self.view.layout(self.customServerAddressField)
+            .top(self.customServerRB.frame.maxY + 10)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+    }
+
+    func toggleRadioButtons(_ sender: Any) {
+        let button = sender as? DLRadioButton
+        if button == standardServerRB {
+            customServerRB.isSelected = false
+            customServerAddressField.tag = 0
+        } else if button == customServerRB {
+            standardServerRB.isSelected = false
+            customServerAddressField.tag = 1
+        }
+        addAddressField()
+    }
+
+    func addAddressField() {
+        UIView.animate(withDuration: 0.5) {
+            if self.customServerAddressField.tag == 0 {
+                self.resetButton.frame.origin.y = self.customServerAddressField.frame.minY
+            } else {
+                self.resetButton.frame.origin.y = self.customServerAddressField.frame.maxY + UIView.UIMarginSpec.mediumMargin
+            }
+            self.activityIndicator.frame.origin.y = self.resetButton.frame.maxY + UIView.UIMarginSpec.mediumMargin
+            self.view.layoutIfNeeded()
+        }
     }
 
     // Add Subview Reset Button
@@ -40,16 +92,17 @@ extension ForgotPasswordViewController {
         self.view.addSubview(resetButton)
         self.view.layout(resetButton)
             .height(44)
-            .top(emailField.height + 70)
+            .top(customServerAddressField.frame.minY)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
     }
 
     // Add Subview Activity Indicator
     func prepareActivityIndicator() {
         self.view.addSubview(activityIndicator)
         self.view.layout(activityIndicator)
-            .top(resetButton.frame.maxY + 170)
+            .top(resetButton.frame.maxY + UIView.UIMarginSpec.mediumMargin)
             .centerHorizontally()
     }
 

--- a/Susi/Controllers/ForgotPasswordController/ForgotPasswordViewController.swift
+++ b/Susi/Controllers/ForgotPasswordController/ForgotPasswordViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Material
+import DLRadioButton
 
 class ForgotPasswordViewController: UIViewController {
 
@@ -28,6 +29,31 @@ class ForgotPasswordViewController: UIViewController {
         textField.detailLabel.text = ControllerConstants.invalidEmail
         textField.delegate = self
         return textField
+    }()
+
+    let standardServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.standardServer, for: .normal)
+        button.isSelected = true
+        return button
+    }()
+
+    let customServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.customServer, for: .normal)
+        return button
+    }()
+
+    let customServerAddressField: TextField = {
+        let textfield = TextField()
+        textfield.placeholderNormalColor = .white
+        textfield.placeholderActiveColor = .white
+        textfield.dividerNormalColor = .white
+        textfield.dividerActiveColor = .white
+        textfield.textColor = .white
+        textfield.tag = 0
+        textfield.placeholder = ControllerConstants.customIPAddress
+        return textfield
     }()
 
     // Setup Reset Button
@@ -53,6 +79,7 @@ class ForgotPasswordViewController: UIViewController {
 
         setupView()
         prepareEmailField()
+        prepareRadioButtons()
         prepareResetButton()
         prepareActivityIndicator()
     }

--- a/Susi/Controllers/LoginController/LoginVCMethods.swift
+++ b/Susi/Controllers/LoginController/LoginVCMethods.swift
@@ -8,11 +8,12 @@
 
 import UIKit
 import BouncyLayout
+import DLRadioButton
 
 extension LoginViewController {
 
     func addTapGesture() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(LoginViewController.dismissKeyboard))
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         self.view.addGestureRecognizer(tap)
     }
 
@@ -20,66 +21,136 @@ extension LoginViewController {
     func setupView() {
         self.view.backgroundColor = UIColor.defaultColor()
 
+        prepareScrollView()
         prepareLogo()
         prepareEmailField()
         preparePasswordField()
+        prepareRadioButtons()
         prepareLoginButton()
         prepareForgotButton()
         prepareSignUpButton()
     }
 
+    // Add Subview Scroll View
+    func prepareScrollView() {
+        self.view.addSubview(scrollView)
+        scrollView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height)
+        scrollView.contentSize = CGSize(width: view.frame.width, height: view.frame.height * 1.25)
+        scrollView.alwaysBounceVertical = true
+    }
+
     // Add Subview Logo
     private func prepareLogo() {
-        self.view.addSubview(susiLogo)
-        self.view.layout(susiLogo).top(50).centerHorizontally()
+        self.scrollView.addSubview(susiLogo)
+        self.scrollView.layout(susiLogo)
+            .top(50)
+            .centerHorizontally()
     }
 
     // Add Subview Email Field
     private func prepareEmailField() {
-        self.view.addSubview(emailField)
-        self.view.layout(emailField)
-            .center(offsetY: -passwordField.height - 80)
+        self.scrollView.addSubview(emailField)
+        self.scrollView.layout(emailField)
+            .top(susiLogo.frame.maxY + susiLogo.frame.height + 30)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+            .width(view.frame.width - 40)
+        self.scrollView.layoutIfNeeded()
     }
 
     // Add Subview Password Field
     private func preparePasswordField() {
-        self.view.addSubview(passwordField)
-        self.view.layout(passwordField)
-            .center(offsetY: 0)
+        self.scrollView.addSubview(passwordField)
+        self.scrollView.layout(passwordField)
+            .top(emailField.frame.maxY + emailField.frame.height + 20)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.scrollView.layoutSubviews()
+    }
+
+    func prepareRadioButtons() {
+        self.scrollView.addSubview(standardServerRB)
+        self.scrollView.layout(standardServerRB)
+            .top(passwordField.frame.maxY + 20)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
+        self.scrollView.layoutSubviews()
+        standardServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.scrollView.addSubview(customServerRB)
+        self.scrollView.layout(customServerRB)
+            .top(standardServerRB.frame.maxY)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.scrollView.layoutSubviews()
+        customServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.scrollView.addSubview(self.customServerAddressField)
+        self.scrollView.layout(self.customServerAddressField)
+            .top(self.customServerRB.frame.maxY + 10)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.scrollView.layoutSubviews()
+    }
+
+    func toggleRadioButtons(_ sender: Any) {
+        let button = sender as? DLRadioButton
+        if button == standardServerRB {
+            customServerRB.isSelected = false
+            customServerAddressField.tag = 0
+        } else if button == customServerRB {
+            standardServerRB.isSelected = false
+            customServerAddressField.tag = 1
+        }
+        addAddressField()
+    }
+
+    func addAddressField() {
+        UIView.animate(withDuration: 0.5) {
+            if self.customServerAddressField.tag == 0 {
+                self.loginButton.frame.origin.y = self.customServerRB.frame.maxY + UIView.UIMarginSpec.smallMargin
+                self.forgotButton.frame.origin.y = self.loginButton.frame.maxY
+                self.signUpButton.frame.origin.y = self.forgotButton.frame.maxY + self.forgotButton.frame.height
+            } else {
+                self.loginButton.frame.origin.y = self.customServerRB.frame.maxY + UIView.UIMarginSpec.largeMatgin + 20
+                self.forgotButton.frame.origin.y = self.loginButton.frame.maxY + UIView.UIMarginSpec.smallMargin
+                self.signUpButton.frame.origin.y  = self.forgotButton.frame.maxY + self.forgotButton.frame.height
+            }
+            self.scrollView.layoutIfNeeded()
+        }
     }
 
     // Add Subview Login Button
     private func prepareLoginButton() {
-        self.view.addSubview(loginButton)
-        self.view.layout(loginButton)
-            .height(44)
-            .center(offsetY: passwordField.height + 60)
+        self.scrollView.addSubview(loginButton)
+        self.scrollView.layout(loginButton)
+            .top(customServerRB.frame.maxY + 20)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
+        self.scrollView.layoutSubviews()
     }
 
     // Add Subview Forgot Button
     private func prepareForgotButton() {
-        self.view.addSubview(forgotButton)
-        self.view.layout(forgotButton)
-            .height(44)
-            .center(offsetY: passwordField.height + loginButton.height + 70)
+        self.scrollView.addSubview(forgotButton)
+        self.scrollView.layout(forgotButton)
+            .top(loginButton.frame.maxY + UIView.UIMarginSpec.smallMargin)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
+        self.scrollView.layoutSubviews()
     }
 
     // Add Subview Sign Up Button
     private func prepareSignUpButton() {
-        self.view.addSubview(signUpButton)
-        self.view.layout(signUpButton)
-            .height(44)
-            .bottom(20)
+        self.scrollView.addSubview(signUpButton)
+        self.scrollView.layout(signUpButton)
+            .top(forgotButton.frame.maxY + forgotButton.frame.height)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
     }
 
     // Login User
@@ -92,7 +163,7 @@ extension LoginViewController {
                 Client.UserKeys.Login: emailField.text!.lowercased(),
                 Client.UserKeys.Password: passwordField.text!,
                 Client.ChatKeys.ResponseType: Client.ChatKeys.AccessToken
-                ] as [String : Any]
+            ] as [String : Any]
 
             Client.sharedInstance.loginUser(params as [String : AnyObject]) { (_, success, message) in
                 DispatchQueue.main.async {
@@ -156,12 +227,24 @@ extension LoginViewController {
             passwordField.isErrorRevealed = true
             return false
         }
+        if customServerAddressField.tag == 1 {
+            if let address = customServerAddressField.text, address.isEmpty {
+                return false
+            }
+        }
         return true
     }
 
     // Login User
     func completeLogin() {
         let layout = BouncyLayout()
+
+        if customServerAddressField.tag == 0 {
+            UserDefaults.standard.set(Client.APIURLs.SusiAPI, forKey: ControllerConstants.UserDefaultsKeys.ipAddress)
+        } else {
+            UserDefaults.standard.set(customServerAddressField.text!, forKey: ControllerConstants.UserDefaultsKeys.ipAddress)
+        }
+
         let vc = MainViewController(collectionViewLayout: layout)
         let nvc = AppNavigationController(rootViewController: vc)
         self.present(nvc, animated: true, completion: {

--- a/Susi/Controllers/LoginController/LoginViewController.swift
+++ b/Susi/Controllers/LoginController/LoginViewController.swift
@@ -10,8 +10,11 @@ import UIKit
 import Material
 import Toast_Swift
 import SwiftValidators
+import DLRadioButton
 
 class LoginViewController: UIViewController {
+
+    let scrollView = UIScrollView()
 
     // Setup Susi Logo
     let susiLogo: UIImageView = {
@@ -71,8 +74,34 @@ class LoginViewController: UIViewController {
         return button
     }()
 
+    let standardServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.standardServer, for: .normal)
+        button.isSelected = true
+        return button
+    }()
+
+    let customServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.customServer, for: .normal)
+        return button
+    }()
+
+    let customServerAddressField: TextField = {
+        let textfield = TextField()
+        textfield.placeholderNormalColor = .white
+        textfield.placeholderActiveColor = .white
+        textfield.dividerNormalColor = .white
+        textfield.dividerActiveColor = .white
+        textfield.textColor = .white
+        textfield.tag = 0
+        textfield.placeholder = ControllerConstants.customIPAddress
+        return textfield
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
         setupView()
         checkSession()
         addTapGesture()

--- a/Susi/Controllers/SignUpController/SignUpVCMethods.swift
+++ b/Susi/Controllers/SignUpController/SignUpVCMethods.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import DLRadioButton
 
 extension SignUpViewController {
 
@@ -22,6 +23,7 @@ extension SignUpViewController {
         prepareEmailField()
         preparePasswordField()
         prepareConfirmPasswordField()
+        prepareRadioButtons()
         prepareSignUpButton()
     }
 
@@ -41,27 +43,79 @@ extension SignUpViewController {
     private func prepareEmailField() {
         self.view.addSubview(emailField)
         self.view.layout(emailField)
-            .center(offsetY: -confirmPasswordField.height - passwordField.height - 180)
+            .top(70)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
     }
 
     // Add Subview Password Field
     private func preparePasswordField() {
         self.view.addSubview(passwordField)
         self.view.layout(passwordField)
-            .center(offsetY: -confirmPasswordField.height - 100)
+            .top(emailField.frame.maxY + emailField.frame.height)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
     }
 
     // Add Subview Confirm Password Field
     private func prepareConfirmPasswordField() {
         self.view.addSubview(confirmPasswordField)
         self.view.layout(confirmPasswordField)
-            .center(offsetY: 0)
+            .top(passwordField.frame.maxY + passwordField.frame.height)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+    }
+
+    func prepareRadioButtons() {
+        self.view.addSubview(standardServerRB)
+        self.view.layout(standardServerRB)
+            .top(confirmPasswordField.frame.maxY + UIView.UIMarginSpec.mediumMargin)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+            .height(44)
+        self.view.layoutSubviews()
+        standardServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.view.addSubview(customServerRB)
+        self.view.layout(customServerRB)
+            .top(standardServerRB.frame.maxY)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+        customServerRB.addTarget(self, action: #selector(toggleRadioButtons), for: .touchUpInside)
+
+        self.view.addSubview(self.customServerAddressField)
+        self.view.layout(self.customServerAddressField)
+            .top(self.customServerRB.frame.maxY + 10)
+            .left(UIView.UIMarginSpec.mediumMargin)
+            .right(UIView.UIMarginSpec.mediumMargin)
+        self.view.layoutSubviews()
+    }
+
+    func toggleRadioButtons(_ sender: Any) {
+        let button = sender as? DLRadioButton
+        if button == standardServerRB {
+            customServerRB.isSelected = false
+            customServerAddressField.tag = 0
+        } else if button == customServerRB {
+            standardServerRB.isSelected = false
+            customServerAddressField.tag = 1
+        }
+        addAddressField()
+    }
+
+    func addAddressField() {
+        UIView.animate(withDuration: 0.5) {
+            if self.customServerAddressField.tag == 0 {
+                self.signUpButton.frame.origin.y = self.customServerAddressField.frame.minY
+            } else {
+                self.signUpButton.frame.origin.y = self.customServerAddressField.frame.maxY + UIView.UIMarginSpec.mediumMargin
+            }
+            self.view.layoutIfNeeded()
+        }
     }
 
     // Add Subview Sign Up Button
@@ -69,7 +123,7 @@ extension SignUpViewController {
         self.view.addSubview(signUpButton)
         self.view.layout(signUpButton)
             .height(44)
-            .center(offsetY: confirmPasswordField.height + 70)
+            .top(customServerAddressField.frame.minY)
             .left(UIView.UIMarginSpec.mediumMargin)
             .right(UIView.UIMarginSpec.mediumMargin)
     }

--- a/Susi/Controllers/SignUpController/SignUpViewController.swift
+++ b/Susi/Controllers/SignUpController/SignUpViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Material
+import DLRadioButton
 
 class SignUpViewController: UIViewController {
 
@@ -63,6 +64,31 @@ class SignUpViewController: UIViewController {
         button.setTitleColor(UIColor.defaultColor(), for: .normal)
         button.addTarget(self, action: #selector(performSignUp), for: .touchUpInside)
         return button
+    }()
+
+    let standardServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.standardServer, for: .normal)
+        button.isSelected = true
+        return button
+    }()
+
+    let customServerRB: DLRadioButton = {
+        let button = DLRadioButton()
+        button.setTitle(ControllerConstants.customServer, for: .normal)
+        return button
+    }()
+
+    let customServerAddressField: TextField = {
+        let textfield = TextField()
+        textfield.placeholderNormalColor = .white
+        textfield.placeholderActiveColor = .white
+        textfield.dividerNormalColor = .white
+        textfield.dividerActiveColor = .white
+        textfield.textColor = .white
+        textfield.tag = 0
+        textfield.placeholder = ControllerConstants.customIPAddress
+        return textfield
     }()
 
     override func viewDidLoad() {

--- a/Susi/Helpers/ControllerConstants.swift
+++ b/Susi/Helpers/ControllerConstants.swift
@@ -33,6 +33,9 @@ class ControllerConstants {
     static let outgoingCell = "outgoingCell"
     static let defaultMessage = "Sample message"
     static let defaultWebSearchImage = "no-image"
+    static let standardServer = "Standard Server"
+    static let customServer = "Custom Server"
+    static let customIPAddress = "Address http://"
 
     struct Login {
         static let susiImage = "susi"
@@ -80,6 +83,7 @@ class ControllerConstants {
         static let speechOutput = "speechOutput"
         static let speechOutputAlwaysOn = "speechOutputAlwaysOn"
         static let wallpaper = "wallpaper"
+        static let ipAddress = "ipAddress"
     }
 
 }

--- a/Susi/Model/Client/Convenience.swift
+++ b/Susi/Model/Client/Convenience.swift
@@ -15,7 +15,7 @@ extension Client {
 
     func loginUser(_ params: [String : AnyObject], _ completion: @escaping(_ user: User?, _ success: Bool, _ error: String) -> Void) {
 
-        let url = getApiUrl(APIURLs.SusiAPI, Methods.Login)
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.Login)
 
         _ = makeRequest(url, .post, [:], parameters: params, completion: { (results, message) in
 
@@ -35,7 +35,7 @@ extension Client {
 
     func registerUser(_ params: [String : AnyObject], _ completion: @escaping(_ success: Bool, _ error: String) -> Void) {
 
-        let url = getApiUrl(APIURLs.SusiAPI, Methods.Register)
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.Register)
 
         _ = makeRequest(url, .post, [:], parameters: params, completion: { (results, message) in
 
@@ -58,7 +58,7 @@ extension Client {
 
     func resetPassword(_ params: [String : AnyObject], _ completion: @escaping(_ success: Bool, _ error: String) -> Void) {
 
-        let url = getApiUrl(APIURLs.SusiAPI, Methods.ResetPassword)
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.ResetPassword)
 
         _ = makeRequest(url, .get, [:], parameters: params, completion: { (results, message) in
 
@@ -89,7 +89,7 @@ extension Client {
 
     func queryResponse(_ params: [String : AnyObject], _ completion: @escaping(_ response: Message?, _ success: Bool, _ error: String?) -> Void) {
 
-        let url = getApiUrl(APIURLs.SusiAPI, Methods.Chat)
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.Chat)
 
         _ = makeRequest(url, .get, [:], parameters: params, completion: { (results, message) in
 


### PR DESCRIPTION
Fixes issue #72: option to choose between custom and standard server

Changes: 
- Added radio buttons for toggling 
- Saved the URL in UserDefaults which can be used for making API calls

Screenshots for the change: 

![screen shot 2017-06-09 at 5 10 47 pm](https://user-images.githubusercontent.com/8962264/26974067-51f97cb6-4d37-11e7-91af-04b4e8f41ad9.png)

![screen shot 2017-06-09 at 7 13 28 pm](https://user-images.githubusercontent.com/8962264/26996654-480b1962-4d91-11e7-9e30-69cbe42f86a7.png)

