### PR TITLE
Fix: pass access token with each request

### DIFF
--- a/Susi/Controllers/MainViewController/MainVCMethods.swift
+++ b/Susi/Controllers/MainViewController/MainVCMethods.swift
@@ -137,6 +137,11 @@ extension MainViewController {
                 params[Client.ChatKeys.Longitude] = location.coordinate.longitude as AnyObject
             }
 
+            if let userData = UserDefaults.standard.dictionary(forKey: ControllerConstants.UserDefaultsKeys.user) as [String : AnyObject]? {
+                let user = User(dictionary: userData)
+                params[Client.ChatKeys.AccessToken] = user.accessToken as AnyObject
+            }
+
             Client.sharedInstance.queryResponse(params) { (messages, success, _) in
                 DispatchQueue.main.async {
                     if success {


### PR DESCRIPTION
Fixes issue #117 : pass access token with each request for authenticated users

Changes: 
- grab user object and pass the access token from the object in the request