### PR TITLE
fixed the upload-ipa script

### DIFF
--- a/upload-ipa.sh
+++ b/upload-ipa.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 if [[ $CIRCLE_BRANCH != pull* ]]
 then
         git config --global user.name "chashmeetsingh"
@@ -7,23 +5,36 @@ then
         git clone --quiet --branch=ipa https://chashmeetsingh:$GITHUB_API_KEY@github.com/fossasia/susi_iOS ipa > /dev/null
         ls
 
-        cp -r $HOME/Library/Developer/Xcode/DerivedData/Susi-*/Build/Products/Debug-iphonesimulator/Susi.app ipa/Susi.app
         cd ipa
+
+        # Delete all stale files
+        git rm -rf * .??*
+
+        # temporary commit to persist delete file changes
+        git commit -m "temp"
+
+        # Checkout a temporary branch to delete original ipa branch later
+        git checkout --orphan temp
+
+        cp -r $HOME/Library/Developer/Xcode/DerivedData/Susi-*/Build/Products/Debug-iphonesimulator/Susi.app Susi.app
         mkdir Payload
         mv Susi.app Payload/
         zip -r Payload.zip Payload
         mv Payload.zip Susi.ipa
         rm -rf Payload/
-        ls
+        ls -a
 
-        git rm -rf * *.* .travis.yml .github .gitignore
-        ls
-        git add .
+	# Add the SUSI ipa
+        git add Susi.ipa
 
-        git commit -am "[Circle CI] Update Susi.app"
-
+        git commit -am "[Circle CI] Updated Susi.ipa"
+        
+        # Delete original ipa branch
         git branch -D ipa
+
+        # Rename 'temp' branch to ipa
         git branch -m ipa
 
+        # Perform force push since histories are unrelated
         git push origin ipa --force --quiet > /dev/null
 fi


### PR DESCRIPTION
Fixes issue #168 : Fixed the upload_ipa script to delete all the stale files and upload ipa properly. 

Changes: 
Modified upload_ipa.sh script to delete stale files, add new ipa to a fresh orphan branch and rename it to ipa just like I did in susi_android and open-event-android

Note:  It is working locally but I cannot confirm working until PR merges and Circle Build runs with a commit that is not in a Pull Request due to the check if ```[[ $CIRCLE_BRANCH != pull* ]]```

Screenshots for the change: 
N/A
