### PR TITLE
fixed pathspec error in remove stale files command

### DIFF
--- a/upload-ipa.sh
+++ b/upload-ipa.sh
@@ -8,7 +8,8 @@ then
         cd ipa
 
         # Delete all stale files
-        git rm -rf * .??*
+	find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null
+	git add .
 
         # temporary commit to persist delete file changes
         git commit -m "temp"


### PR DESCRIPTION
Fixes issue #168 which could not be completely solved in last pull request.

I checked the logs and there was pathspec error while attempting to delete .git folder. This PR uses a little different approach to remove stale files. It must work but again I cannot assure till it passes after merging.

@chashmeetsingh Please check the commands in this PR upto pushing to ipa branch on your system as well to confirm everything works.

Screenshots for the change: 
N/A