### PR TITLE
Added Style guide and Best Practices to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Please help us follow the best practice to make it easy for the reviewer as well
 * Follow uniform design practices. The design language must be consistent throughout the app.
 * The pull request will not get merged until and unless the commits are squashed. In case there are multiple commits on the PR, the commit author needs to squash them and not the maintainers cherrypicking and merging squashes.
 * If the PR is related to any front end change, please attach relevant screenshots in the pull request description.
+* Please follow the guides and code standards: [Swift Style Guide](https://github.com/linkedin/swift-style-guide)
+* Please follow the good iOS development practices: [iOS Good Practices](https://github.com/futurice/ios-good-practices)
 
 ## License
 


### PR DESCRIPTION
Fixes #37 : Added Swift Style Guide and iOS Good practices to **Code practices** section

Changes: As I mentioned in issue #37 I added Swift style guide and Good iOS Development Practices to Readme.md
Link for Style Guide: [Swift Style Guide](https://github.com/linkedin/swift-style-guide)
Link for good practices: [iOS Good Practices](https://github.com/futurice/ios-good-practices)
