### PR TITLE
Resolved overlapping first chat issue

### DIFF
--- a/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
+++ b/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
@@ -102,7 +102,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
 
     // Set Edge Insets
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 2, left: 0, bottom: 2, right: 0)
+        return UIEdgeInsets(top: 44, left: 0, bottom: 2, right: 0)
     }
 
     override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {


### PR DESCRIPTION
Fixes #281 

Changes: Resolved overlapping first chat issue
(SUSI android follow the top to bottom chat flow so keep that flow same here)

Screenshots for the change: 
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/20956124/41091601-8d997c26-6a64-11e8-80c8-eee5a0810604.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/20956124/41091286-d0361a36-6a63-11e8-8914-c950c659e4a3.png">
</td></tr>
</table>