### PR TITLE
Allowing the user to rate the skill and handled related cases

### DIFF
--- a/Susi.xcodeproj/project.pbxproj
+++ b/Susi.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3BC1D8D5203B177E003E62F9 /* noConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1D8D3203B177E003E62F9 /* noConnectionViewController.swift */; };
 		3BC1D8D6203B177E003E62F9 /* noConnectionNetworkStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1D8D4203B177E003E62F9 /* noConnectionNetworkStatus.swift */; };
 		403E7F4220BCBCFB00D7B48B /* DevicesActivityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403E7F4120BCBCFB00D7B48B /* DevicesActivityViewController.swift */; };
+		40623B7F20D243910013FE60 /* Ratings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40623B7E20D243910013FE60 /* Ratings.swift */; };
 		406F100620ADFEED00808E4C /* OnboardingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 406F100520ADFEED00808E4C /* OnboardingUITests.swift */; };
 		40701E7F20BEAC8100B92D81 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40701E7E20BEAC8100B92D81 /* RatingView.swift */; };
 		40799A7620BBAD9800271718 /* DeviceInstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40799A7520BBAD9800271718 /* DeviceInstructionsViewController.swift */; };
@@ -97,9 +98,9 @@
 		6DE809D11F34DC6500CAE674 /* TrainingAudioRecorderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE809D01F34DC6500CAE674 /* TrainingAudioRecorderDelegate.swift */; };
 		6DEE71121F2C9DC900A512CF /* AppNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEE71111F2C9DC900A512CF /* AppNavigationController.swift */; };
 		6DFC75B91EE077E9002F92BA /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFC75B81EE077E9002F92BA /* ForgotPasswordViewController.swift */; };
+		71DF0561EA8079C5C53174C1 /* Pods_Susi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C564B012515FE5529232089A /* Pods_Susi.framework */; };
 		94889CA61F7CCD370028B8C3 /* GeneralViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94889CA51F7CCD370028B8C3 /* GeneralViewController.swift */; };
 		94889CAE1F7CEAA80028B8C3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94889CB01F7CEAA80028B8C3 /* Localizable.strings */; };
-		A51AEC7AB0CB0D73341602BA /* Pods_Susi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C564B012515FE5529232089A /* Pods_Susi.framework */; };
 		F09A34A3B776419996088BB5 /* Pods_SusiUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5994B8E49F09387802A1EB7A /* Pods_SusiUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -118,6 +119,7 @@
 		3BC1D8D3203B177E003E62F9 /* noConnectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = noConnectionViewController.swift; sourceTree = "<group>"; };
 		3BC1D8D4203B177E003E62F9 /* noConnectionNetworkStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = noConnectionNetworkStatus.swift; sourceTree = "<group>"; };
 		403E7F4120BCBCFB00D7B48B /* DevicesActivityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesActivityViewController.swift; sourceTree = "<group>"; };
+		40623B7E20D243910013FE60 /* Ratings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings.swift; sourceTree = "<group>"; };
 		406F100520ADFEED00808E4C /* OnboardingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingUITests.swift; sourceTree = "<group>"; };
 		40701E7E20BEAC8100B92D81 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		40799A7520BBAD9800271718 /* DeviceInstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInstructionsViewController.swift; sourceTree = "<group>"; };
@@ -240,7 +242,7 @@
 				6D2898421F14507700B6151A /* libsnowboy-detect.a in Frameworks */,
 				6DE264911F0278A900EBAD13 /* Speech.framework in Frameworks */,
 				6D35E4881EE70F9000188E1F /* Accelerate.framework in Frameworks */,
-				A51AEC7AB0CB0D73341602BA /* Pods_Susi.framework in Frameworks */,
+				71DF0561EA8079C5C53174C1 /* Pods_Susi.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -560,6 +562,7 @@
 				6D61B9B21EEBAB4000CD3536 /* TableAction.swift */,
 				6D9C0D281E7B223A00199828 /* User.swift */,
 				6D61B9B01EEBAB0200CD3536 /* WebsearchAction.swift */,
+				40623B7E20D243910013FE60 /* Ratings.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -877,6 +880,7 @@
 				6DE44E0F1E769AD300215B85 /* Color.swift in Sources */,
 				40701E7F20BEAC8100B92D81 /* RatingView.swift in Sources */,
 				6D017B251F4EAF86004BDE7E /* SkillListingViewController.swift in Sources */,
+				40623B7F20D243910013FE60 /* Ratings.swift in Sources */,
 				6D395D1D1F58966900BCC3C5 /* SkillDetailExampleCell.swift in Sources */,
 				3BC1D8D5203B177E003E62F9 /* noConnectionViewController.swift in Sources */,
 				6D395D1F1F589CC000BCC3C5 /* SkillDetailVCMethods.swift in Sources */,

--- a/Susi/Controllers/SkillDetailViewController/SkillDetailViewController.swift
+++ b/Susi/Controllers/SkillDetailViewController/SkillDetailViewController.swift
@@ -33,6 +33,8 @@ class SkillDetailViewController: GeneralViewController {
     var skill: Skill?
     var chatViewController: ChatViewController?
     var selectedExample: String?
+    var submitRatingParams: [String: AnyObject] = [:]
+    var getRatingParam: [String: AnyObject] = [:]
 
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var skillLabel: UILabel!
@@ -42,7 +44,11 @@ class SkillDetailViewController: GeneralViewController {
     @IBOutlet weak var skillDescription: UILabel!
     @IBOutlet weak var examplesCollectionView: UICollectionView!
     @IBOutlet weak var exampleHeading: UILabel!
-    @IBOutlet weak var ratingView: RatingView!
+    @IBOutlet weak var ratingView: RatingView! {
+        didSet {
+            ratingView.delegate = self
+        }
+    }
     @IBOutlet weak var averageRatingLabel: UILabel!
     @IBOutlet weak var totalRatingsLabel: UILabel!
     @IBOutlet weak var topAvgRatingLabel: UILabel!
@@ -73,6 +79,11 @@ class SkillDetailViewController: GeneralViewController {
         roundedCorner()
         setupTryItTarget()
         addSkillDescription()
+        getRatingByUser()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
         setupFiveStarData()
         setupBarChart()
         addContentType()

--- a/Susi/Model/Client/Constants.swift
+++ b/Susi/Model/Client/Constants.swift
@@ -27,7 +27,8 @@ extension Client {
         static let ChangePassword = "/aaa/changepassword.json"
         static let GetGroups = "/cms/getGroups.json"
         static let GetSkillList = "/cms/getSkillList.json"
-        static let fiveStarRateSkill = "/cms/fiveStarRateSkill.json"
+        static let FiveStarRateSkill = "/cms/fiveStarRateSkill.json"
+        static let GetRatingByUser = "/cms/getRatingByUser.json"
         static let baseSkillImagePath = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/"
     }
 
@@ -38,6 +39,10 @@ extension Client {
         static let PasswordInvalid = "Password chosen is invalid."
         static let NoSkillsPresent = "No skills present."
         static let NoRatingsPresent = "No ratings present."
+        static let NotSubmittedRatings = "Problem submitting ratings"
+        static let SuccessSubmitRating = "Rating submitted successfully"
+        static let UserRatingNotFetched = "Problem fetching user rating"
+        static let SuccessUserRating = "Fetched user rating successfully"
     }
 
     struct UserKeys {
@@ -143,6 +148,7 @@ extension Client {
         static let group = "group"
         static let groups = "groups"
         static let skills = "skills"
+        static let skill = "skill"
         static let image = "image"
         static let authorURL = "author_url"
         static let examples = "examples"
@@ -166,6 +172,8 @@ extension Client {
         static let positive = "positive"
         static let negative = "negative"
         static let stars = "stars"
+        static let ratings = "ratings"
+        static let AccessToken = "access_token"
     }
 
 }

--- a/Susi/Model/Client/Convenience.swift
+++ b/Susi/Model/Client/Convenience.swift
@@ -430,9 +430,9 @@ extension Client {
             return
         })
     }
-/*
-    func getRatings(_ params: [String: AnyObject], _ completion: @escaping(_ fiveStarRating: FiveStarRating?, _ success: Bool, _ error: String?) -> Void) {
-        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.fiveStarRateSkill)
+
+    func submitRating(_ params: [String: AnyObject], _ completion: @escaping(_ updatedRatings: Ratings?, _ success: Bool, _ error: String?) -> Void) {
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.FiveStarRateSkill)
         _ = makeRequest(url, .get, [:], parameters: params, completion: { (results, message) in
             if let _ = message {
                 completion(nil, false, ResponseMessages.ServerError)
@@ -443,16 +443,40 @@ extension Client {
                     return
                 }
 
-                if let ratings = response[Client.SkillListing.skills] as? [String: AnyObject] {
-                    completion(ratings, true, nil)
+                if let ratings = response[Client.FiveStarRating.ratings] as? [String: AnyObject] {
+                    let newRatings = Ratings(dictionary: ratings)
+                    completion(newRatings, true, ResponseMessages.SuccessSubmitRating)
                     return
                 }
-                completion(nil, false, ResponseMessages.NoSkillsPresent)
+                completion(nil, false, ResponseMessages.NotSubmittedRatings)
                 return
             }
             return
         })
     }
- */
+
+    func getRatingByUser(_ params: [String: AnyObject], _ completion: @escaping(_ userRating: Int?, _ success: Bool, _ error: String?) -> Void) {
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.GetRatingByUser)
+        _ = makeRequest(url, .get, [:], parameters: params, completion: { (results, message) in
+            if let _ = message {
+                completion(nil, false, ResponseMessages.ServerError)
+            } else if let results = results {
+
+                guard let response = results as? [String: AnyObject] else {
+                    completion(nil, false, ResponseMessages.InvalidParams)
+                    return
+                }
+
+                if let ratings = response[Client.FiveStarRating.ratings] as? [String: AnyObject] {
+                    let ratingByUser = ratings[Client.FiveStarRating.stars] as? Int
+                    completion(ratingByUser, true, ResponseMessages.SuccessUserRating)
+                    return
+                }
+                completion(nil, false, ResponseMessages.UserRatingNotFetched)
+                return
+            }
+            return
+        })
+    }
 
 }

--- a/Susi/Model/Ratings.swift
+++ b/Susi/Model/Ratings.swift
@@ -1,0 +1,30 @@
+//
+//  Ratings.swift
+//  Susi
+//
+//  Created by JOGENDRA on 14/06/18.
+//  Copyright © 2018 FOSSAsia. All rights reserved.
+//
+
+import Foundation
+
+class Ratings: NSObject {
+    var oneStar: Int = 0
+    var twoStar: Int = 0
+    var threeStar: Int = 0
+    var fourStar: Int = 0
+    var fiveStar: Int = 0
+    var totalStar: Int = 0
+    var average: Double = 0.0
+
+    convenience init(dictionary: [String: AnyObject]) {
+        self.init()
+        oneStar = dictionary[Client.FiveStarRating.oneStar] as? Int ?? 0
+        twoStar = dictionary[Client.FiveStarRating.twoStar] as? Int ?? 0
+        threeStar = dictionary[Client.FiveStarRating.threeStar] as? Int ?? 0
+        fourStar = dictionary[Client.FiveStarRating.fourStar] as? Int ?? 0
+        fiveStar = dictionary[Client.FiveStarRating.fiveSatr] as? Int ?? 0
+        totalStar = dictionary[Client.FiveStarRating.totalStar] as? Int ?? 0
+        average = dictionary[Client.FiveStarRating.average] as? Double ?? 0.0
+    }
+}

--- a/Susi/Model/Skill.swift
+++ b/Susi/Model/Skill.swift
@@ -26,8 +26,11 @@ class Skill: NSObject {
     var fiveStar: Int = 0
     var totalRatings: Int = 0
     var averageRating: Double = 0.0
+    var skillKeyName: String = ""
+    var model: String = ""
+    var group: String = ""
 
-    init(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject], skillKey: String) {
         super.init()
         authorUrl = dictionary[Client.SkillListing.authorURL] as? String ?? ""
         examples = dictionary[Client.SkillListing.examples] as? [String] ?? []
@@ -45,6 +48,9 @@ class Skill: NSObject {
         fiveStar = stars[Client.FiveStarRating.fiveSatr] as? Int ?? 0
         totalRatings = stars[Client.FiveStarRating.totalStar] as? Int ?? 0
         averageRating = stars[Client.FiveStarRating.average] as? Double ?? 0.0
+        skillKeyName = skillKey
+        model = dictionary[Client.SkillListing.model] as? String ?? ""
+        group = dictionary[Client.SkillListing.group] as? String ?? ""
     }
 
     static func getAllSkill(_ skills: [String: AnyObject], _ model: String, _ group: String, _ language: String) -> [Skill] {
@@ -52,7 +58,10 @@ class Skill: NSObject {
         for skill in skills {
 
             print(skill)
-            let newSkill = Skill(dictionary: skill.value as! [String: AnyObject])
+            guard let skillValueDictionary = skill.value as? [String: AnyObject] else {
+                return skillData
+            }
+            let newSkill = Skill(dictionary: skillValueDictionary, skillKey: skill.0)
             newSkill.imagePath = getImagePath(model, group, language, newSkill.imagePath)
             guard let dict = skill.value as? [String: AnyObject] else {return skillData}
             if let skillRating = dict["skill_rating"] as? [String: AnyObject] {


### PR DESCRIPTION
Fixes #319 

Changes:
- Allow the user to rate the skill - `fiveStarRateSkill` API
- Update rating chart bar as soon as user rate the skills - response rating from `fiveStarRateSkill` API
- Update skill model for modified skill
- Display initial ratings on `RatingView` as filled star if the user already submitted that rating before - `getRatingByUser` API
- Handled all the possible cases for ratings carefully

See **video demonstration** here: https://drive.google.com/open?id=1LmDP8Do7pgbh72K5JHsq5E5ge8Zrvlme