### PR TITLE
Sending device type in chat.json API

### DIFF
--- a/Susi/Controllers/ChatViewController/ChatVCMethods.swift
+++ b/Susi/Controllers/ChatViewController/ChatVCMethods.swift
@@ -183,7 +183,8 @@ extension ChatViewController {
             var params: [String: AnyObject] = [
                 Client.WebsearchKeys.Query: text as AnyObject,
                 Client.ChatKeys.TimeZoneOffset: ControllerConstants.timeZone as AnyObject,
-                Client.ChatKeys.Language: Locale.current.languageCode as AnyObject
+                Client.ChatKeys.Language: Locale.current.languageCode as AnyObject,
+                Client.ChatKeys.deviceType: ControllerConstants.deviceType as AnyObject
             ]
 
             saveMessage(text)

--- a/Susi/Helpers/ControllerConstants.swift
+++ b/Susi/Helpers/ControllerConstants.swift
@@ -82,6 +82,7 @@ class ControllerConstants {
     static let addNewDevice = "Add New Device"
     static let devices = "Devices"
     static let selectALanguage = "Select a Language"
+    static let deviceType = "iOS"
 
     struct Settings {
         static let enterToSend = "Enter To Send"

--- a/Susi/Model/Client/Constants.swift
+++ b/Susi/Model/Client/Constants.swift
@@ -77,6 +77,7 @@ extension Client {
         static let ShortenedUrl = "finalUrl"
         static let Image = "image"
         static let Cognitions = "cognitions"
+        static let deviceType = "device_type"
     }
 
     struct WebsearchKeys {


### PR DESCRIPTION
Fixes #334 

Changes:
Send device type in `chat.json` API calling Param
```
"device" : "iOS"
```

Screenshots for the change: 
N/A