### PR TITLE
Sending country name and country code in chat.json API

### DIFF
--- a/Susi/Controllers/ChatViewController/ChatVCMethods.swift
+++ b/Susi/Controllers/ChatViewController/ChatVCMethods.swift
@@ -198,6 +198,13 @@ extension ChatViewController {
                 params[Client.ChatKeys.AccessToken] = user.accessToken as AnyObject
             }
 
+            if let countryCode = Locale.current.regionCode {
+                params[Client.ChatKeys.CountryCode] = countryCode as AnyObject
+                if let countryName = countryName(from: countryCode) {
+                    params[Client.ChatKeys.CountryName] = countryName as AnyObject
+                }
+            }
+
             Client.sharedInstance.queryResponse(params) { (messages, success, _) in
                 DispatchQueue.main.async {
                     if let messages = messages, success {
@@ -210,6 +217,13 @@ extension ChatViewController {
                 }
             }
         }
+    }
+
+    // Get county name from country code
+    func countryName(from countryCode: String) -> String? {
+        let name = (Locale.current as NSLocale).displayName(forKey: .countryCode, value: countryCode)
+            // Country name was found
+            return name
     }
 
     // downloads messages from user history

--- a/Susi/Model/Client/Constants.swift
+++ b/Susi/Model/Client/Constants.swift
@@ -77,6 +77,8 @@ extension Client {
         static let ShortenedUrl = "finalUrl"
         static let Image = "image"
         static let Cognitions = "cognitions"
+        static let CountryName = "country_name"
+        static let CountryCode = "country_code"
     }
 
     struct WebsearchKeys {


### PR DESCRIPTION
Fixes #331 

Changes:
Sending country name and country code in `chat.json` API

Screenshots for the change: 
N/A