### PR TITLE
Adding support for sending multiline text in chat

### DIFF
--- a/Susi/Controllers/ChatViewController/ChatVCMethods.swift
+++ b/Susi/Controllers/ChatViewController/ChatVCMethods.swift
@@ -33,7 +33,11 @@ extension ChatViewController {
             let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as AnyObject).cgRectValue
             let isKeyboardShowing = notification.name == NSNotification.Name.UIKeyboardWillShow
 
-            bottomConstraint?.constant = isKeyboardShowing ? -keyboardFrame!.height : 0
+            if #available(iOS 11.0, *) {
+                bottomConstraint?.constant = isKeyboardShowing ? -keyboardFrame!.height + view.safeAreaInsets.bottom : 0
+            } else {
+                bottomConstraint?.constant = isKeyboardShowing ? -keyboardFrame!.height : 0
+            }
 
             collectionView?.frame = isKeyboardShowing ? CGRect(x: 0, y: 20, width: view.frame.width, height: view.frame.height - keyboardFrame!.height - 71) :
                 CGRect(x: 0, y: 20, width: view.frame.width, height: view.frame.height - 71)

--- a/Susi/Controllers/ChatViewController/ChatViewController.swift
+++ b/Susi/Controllers/ChatViewController/ChatViewController.swift
@@ -57,13 +57,13 @@ class ChatViewController: UICollectionViewController {
     }()
 
     // chat input field
-    lazy var inputTextField: UITextField = {
-        let textField = UITextField()
-        textField.placeholder = ControllerConstants.askSusi.localized()
+    lazy var inputTextField: UITextView = {
+        let textField = UITextView()
+        textField.text = ControllerConstants.askSusi.localized()
+        textField.textColor = UIColor.lightGray
         textField.delegate = self
         textField.accessibilityIdentifier = ControllerConstants.TestKeys.chatInputView
         textField.font = UIFont.systemFont(ofSize: 16)
-        textField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         return textField
     }()
 
@@ -163,14 +163,14 @@ class ChatViewController: UICollectionViewController {
 
         reachability.whenReachable = { reachability in
             DispatchQueue.main.async {
-                self.inputTextField.isEnabled = true
+                self.inputTextField.isEditable = true
                 self.alert.dismiss(animated: true, completion: nil)
             }
         }
 
         reachability.whenUnreachable = { reachability in
             DispatchQueue.main.async {
-                self.inputTextField.isEnabled = false
+                self.inputTextField.isEditable = false
                 self.present(self.alert, animated: true, completion: nil)
             }
         }

--- a/Susi/Controllers/ChatViewController/TextFieldDelegate.swift
+++ b/Susi/Controllers/ChatViewController/TextFieldDelegate.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-extension ChatViewController: UITextFieldDelegate {
+extension ChatViewController: UITextViewDelegate {
 
-    @objc func textFieldDidChange(_ textField: UITextField) {
+    @objc func textViewDidChange(_ textField: UITextView) {
         if let text = inputTextField.text, text.isEmpty {
             sendButton.tag = 0
             sendButton.setImage(ControllerConstants.Images.microphone, for: .normal)
@@ -24,10 +24,26 @@ extension ChatViewController: UITextFieldDelegate {
         }
     }
 
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if UserDefaults.standard.bool(forKey: ControllerConstants.UserDefaultsKeys.enterToSend) {
-            handleSend()
-            return false
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if inputTextField.textColor == UIColor.lightGray {
+            inputTextField.text = nil
+            inputTextField.textColor = UIColor.black
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if inputTextField.text.isEmpty {
+            inputTextField.text = ControllerConstants.askSusi.localized()
+            inputTextField.textColor = UIColor.lightGray
+        }
+    }
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            if UserDefaults.standard.bool(forKey: ControllerConstants.UserDefaultsKeys.enterToSend) {
+                handleSend()
+                return false
+            }
         }
         return true
     }


### PR DESCRIPTION
Fixes #362 

Changes: Adding support for sending multiline text in chat
- Changes `UITextField` to `UITextView`
- Added `UITextViewDelegate` methods
- Handled `Enter to send`

GIF for the change: 
(Ignore bad quality of GIF - due to big size)
<img src="https://user-images.githubusercontent.com/20956124/42106815-f413fe1e-7bf2-11e8-90fa-97b60c958cdb.gif" width="300">
