### PR TITLE
Displaying skills in descending average ratings order

### DIFF
--- a/Susi/Custom Views/Skill Listing Cells/SkillListingTableCell.swift
+++ b/Susi/Custom Views/Skill Listing Cells/SkillListingTableCell.swift
@@ -22,8 +22,10 @@ class SkillListingTableCell: UITableViewCell {
 
     var skills: [Skill]? {
         didSet {
+            // Sort skills in descending order of average ratings
+            let sortedSkill = skills?.sorted(by: {$0.averageRating > $1.averageRating})
             skillListingCollectionView.skillListController = skillListController
-            skillListingCollectionView.groupSkills = skills
+            skillListingCollectionView.groupSkills = sortedSkill
         }
     }
 


### PR DESCRIPTION
Fixes #337 

Changes: Skills are displayed in descending order of **average ratings**

Screenshots for the change: 
![simulator screen shot - iphone 8 - 2018-07-11 at 13 34 46](https://user-images.githubusercontent.com/20956124/42558691-aecbfc46-850f-11e8-94cb-f9ca0f9508b9.png)
