### PR TITLE
Adding support for audio_play action

### DIFF
--- a/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
+++ b/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
@@ -79,7 +79,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
                 cell.message = message
                 return cell
             }
-        } else if message.actionType == ActionType.video_play.rawValue {
+        } else if message.actionType == ActionType.video_play.rawValue || message.actionType == ActionType.audio_play.rawValue {
             if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ControllerConstants.youtubePlayerCell, for: indexPath) as? YouTubePlayerCell {
                 cell.message = message
                 cell.delegate = self
@@ -110,7 +110,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
                 return CGSize(width: view.frame.width, height: 145)
             } else if let expression = message.answerData?.expression, expression.isValidURL(), expression.isImage() {
                 return CGSize(width: view.frame.width, height: 173)
-            } else if message.actionType == ActionType.video_play.rawValue {
+            } else if message.actionType == ActionType.video_play.rawValue || message.actionType == ActionType.audio_play.rawValue {
                 return CGSize(width: view.frame.width, height: 158)
             }
             return CGSize(width: view.frame.width, height: estimatedFrame.height + 38)

--- a/Susi/Model/Message.swift
+++ b/Susi/Model/Message.swift
@@ -20,6 +20,7 @@ enum ActionType: String {
     case indicatorView
     case stop
     case video_play
+    case audio_play
 }
 
 class Message: Object {
@@ -98,6 +99,9 @@ class Message: Object {
                             message.answerData = AnswerAction(action: action)
                         } else if type == ActionType.video_play.rawValue {
                             message.actionType = ActionType.video_play.rawValue
+                            message.videoData = VideoPlayAction(action: action)
+                        } else if type == ActionType.audio_play.rawValue {
+                            message.actionType = ActionType.audio_play.rawValue
                             message.videoData = VideoPlayAction(action: action)
                         }
                     }


### PR DESCRIPTION
Fixes #383 

Changes: Play video from youtube for `audio_play` action, same as the SUSI Android and Web client.

Screenshots for the change: 
<table>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/20956124/43023953-460d1e2e-8c8a-11e8-99b5-393e2681f9ab.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/20956124/43023954-47cd4464-8c8a-11e8-8de1-4b6453d194a9.png">
</td></tr>
</table>
