### PR TITLE
Make call to SUSI server instead of getting data from github

### DIFF
--- a/Susi/Model/Client/Constants.swift
+++ b/Susi/Model/Client/Constants.swift
@@ -32,7 +32,7 @@ extension Client {
         static let GetRatingByUser = "/cms/getRatingByUser.json"
         static let FeedbackSkill = "/cms/feedbackSkill.json"
         static let GetSkillFeedback = "/cms/getSkillFeedback.json"
-        static let baseSkillImagePath = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/"
+        static let baseSkillImagePath = "/cms/getImage.png"
         static let WifiCredentials = "wifi_credentials"
         static let Auth = "auth"
         static let Config = "config"

--- a/Susi/Model/Skill.swift
+++ b/Susi/Model/Skill.swift
@@ -74,7 +74,7 @@ class Skill: NSObject {
     }
 
     static func getImagePath(_ model: String, _ group: String, _ language: String, _ path: String) -> String {
-        return "\(Client.Methods.baseSkillImagePath)\(model)/\(group)/\(language)/\(path)".replacingOccurrences(of: " ", with: "%20")
+        return "\(Client.APIURLs.SusiAPI)\(Client.Methods.baseSkillImagePath)?model=\(model)&language=\(language)&group=\(group)&image=\(path)".replacingOccurrences(of: " ", with: "%20")
     }
 
 }


### PR DESCRIPTION
Fixes #389 

Changes: Make call to SUSI server instead of getting data from GitHub for skills images - `getImage` API

Screenshots for the change: 
N/A