### PR TITLE
Anonymize the user email address in Feedback section

### DIFF
--- a/Susi/Custom Views/Feedback Display Cell/AllFeedbackCell.swift
+++ b/Susi/Custom Views/Feedback Display Cell/AllFeedbackCell.swift
@@ -18,7 +18,9 @@ class AllFeedbackCell: UITableViewCell {
 
     var feedback: Feedback? {
         didSet {
-            userEmailLabel.text = feedback?.email
+            if let userEmail = feedback?.email, let emailIndex = userEmail.range(of: "@")?.upperBound {
+                userEmailLabel.text = String(userEmail.prefix(upTo: emailIndex)) + "..."
+            }
             feedbackDateLabel.text = feedback?.timeStamp.getFirstChar(10)
             userFeedbackLabel.text = feedback?.feedbackString
             if let userEmail = feedback?.email {

--- a/Susi/Custom Views/Feedback Display Cell/FeedbackDisplayCell.swift
+++ b/Susi/Custom Views/Feedback Display Cell/FeedbackDisplayCell.swift
@@ -17,7 +17,9 @@ class FeedbackDisplayCell: UITableViewCell {
 
     var feedback: Feedback? {
         didSet {
-            userEmailLabel.text = feedback?.email
+            if let userEmail = feedback?.email, let emailIndex = userEmail.range(of: "@")?.upperBound {
+                userEmailLabel.text = String(userEmail.prefix(upTo: emailIndex)) + "..."
+            }
             feedbackDateLabel.text = feedback?.timeStamp.getFirstChar(10)
             userFeedbackLabel.text = feedback?.feedbackString
             if let userEmail = feedback?.email {


### PR DESCRIPTION
Fixes #408, Parent issue #399 

Changes: Anonymize the feedback and only show emails until the @ sign, e.g. "mariobehling@...".

Screenshots for the change: 
<table>
<tr>
<td>Skill Detail Screen</td>
<td>See All Feedback</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/20956124/43991605-338265b0-9d8e-11e8-853e-10a619172e4e.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/20956124/43991606-33b51ac8-9d8e-11e8-887a-c94f0944cb86.png">
</td></tr>
</table>