### PR TITLE
Check if user already registered or not for signup

### DIFF
--- a/Susi/Controllers/SignUpController/SignUpVCMethods.swift
+++ b/Susi/Controllers/SignUpController/SignUpVCMethods.swift
@@ -72,6 +72,7 @@ extension SignUpViewController {
 
     // Sign Up User
     @objc func performSignUp() {
+
         if isValid() {
 
             toggleEditing()
@@ -178,6 +179,30 @@ extension SignUpViewController {
             }
         }
         return true
+    }
+
+    // Check if email is already registered or not
+    func checkIfEmailAlreadyExists() {
+        let emailCheckParam = [
+            Client.UserKeys.CheckEmail: emailTextField.text!.lowercased() as AnyObject
+        ]
+        Client.sharedInstance.checkRegistration(emailCheckParam) { (exists, success) in
+            DispatchQueue.main.async {
+                if success, exists! {
+                    self.view.makeToast(ControllerConstants.emailAlreadyExists)
+                }
+            }
+        }
+    }
+
+}
+
+extension SignUpViewController: UITextFieldDelegate {
+
+    func textFieldDidEndEditing(_ textField: UITextField, reason: UITextFieldDidEndEditingReason) {
+        if textField.accessibilityIdentifier == "email" {
+            checkIfEmailAlreadyExists()
+        }
     }
 
 }

--- a/Susi/Helpers/ControllerConstants.swift
+++ b/Susi/Helpers/ControllerConstants.swift
@@ -87,6 +87,7 @@ class ControllerConstants {
     static let selectALanguage = "Select a Language"
     static let deviceType = "iOS"
     static let skillFeedback = "Skill Feedback"
+    static let emailAlreadyExists = "Email is already registered!"
 
     struct Settings {
         static let enterToSend = "Enter To Send"

--- a/Susi/Model/Client/Constants.swift
+++ b/Susi/Model/Client/Constants.swift
@@ -38,6 +38,7 @@ extension Client {
         static let Auth = "/auth"
         static let Config = "/config"
         static let SpeakerConfig = "/speaker_config"
+        static let CheckRegistration = "/aaa/checkRegistration.json"
     }
 
     struct ResponseMessages {
@@ -65,6 +66,8 @@ extension Client {
         static let ValidSeconds = "valid_seconds"
         static let EmailOfAccount = "changepassword"
         static let NewPassword = "newpassword"
+        static let EmailExists = "exists"
+        static let CheckEmail = "check_email"
     }
 
     struct ChatKeys {

--- a/Susi/Model/Client/Convenience.swift
+++ b/Susi/Model/Client/Convenience.swift
@@ -553,6 +553,29 @@ extension Client {
         })
     }
 
+    func checkRegistration(_ params: [String: AnyObject], _ completion: @escaping(_ emailExists: Bool?, _ success: Bool) -> Void) {
+        let url = getApiUrl(UserDefaults.standard.object(forKey: ControllerConstants.UserDefaultsKeys.ipAddress) as! String, Methods.CheckRegistration)
+        _ = makeRequest(url, .get, [:], parameters: params, completion: { (results, message) in
+            if let _ = message {
+                completion(nil, false)
+            } else if let results = results {
+
+                guard let response = results as? [String: AnyObject] else {
+                    completion(nil, false)
+                    return
+                }
+
+                if let exists = response[Client.UserKeys.EmailExists] as? Bool {
+                    completion(exists, true)
+                    return
+                }
+                completion(nil, false)
+                return
+            }
+            return
+        })
+    }
+
     // MARK: - Smart Speaker Methods
 
     func sendWifiCredentials(_ params: [String: AnyObject], _ completion: @escaping(_ success: Bool, _ error: String?) -> Void) {


### PR DESCRIPTION
Fixes #421 

Changes: Make use of `/aaa/checkRegistration.json` API to check if the user is already registered or not. If the user is already registered it show a toast.

Screenshots for the change: 
N/A