### PR TITLE
Scrollbutton blinking problem fixed

### DIFF
--- a/Susi/Controllers/ChatViewController/ChatVCMethods.swift
+++ b/Susi/Controllers/ChatViewController/ChatVCMethods.swift
@@ -340,7 +340,6 @@ extension ChatViewController {
             let lastItem = messages.count - 1
             let indexPath = IndexPath(item: lastItem, section: 0)
             collectionView?.scrollToItem(at: indexPath, at: .top, animated: true)
-            scrollButton.isHidden = true
         }
     }
 


### PR DESCRIPTION
Fixes #449 

Changes: Now scroll button does not blink when clicked.

Screenshots for the change: 
Now:

![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/31539812/47960297-ce533380-e01e-11e8-9a61-20b60dfbbdaf.gif)

Before:

![current_gif](https://user-images.githubusercontent.com/31539812/47960370-977e1d00-e020-11e8-97c4-5985932d863b.gif)
