### PR TITLE
Scrollbutton and Send button overlapping problem fixed

### DIFF
--- a/Susi/Controllers/ChatViewController/ChatVCMethods.swift
+++ b/Susi/Controllers/ChatViewController/ChatVCMethods.swift
@@ -151,7 +151,7 @@ extension ChatViewController {
     func addScrollButton() {
         view.addSubview(scrollButton)
         view.addConstraintsWithFormat(format: "H:[v0(44)]|", views: scrollButton)
-        view.addConstraintsWithFormat(format: "V:[v0(44)]-70-|", views: scrollButton)
+        view.addConstraintsWithFormat(format: "V:[v0(44)]-85-|", views: scrollButton)
         scrollButton.isHidden = true
     }
 


### PR DESCRIPTION
Fixes #453 

Changes: Scrollbutton does not overlap with the send button in chat. 

Screenshots for the change: 
![screenshot 2018-11-04 at 2 59 11 pm](https://user-images.githubusercontent.com/31539812/47962560-a4146c80-e044-11e8-8428-6f82b33f7e69.png)
