### PR TITLE
Password length limit removed from login page

### DIFF
--- a/Susi/Controllers/LoginController/LoginVCMethods.swift
+++ b/Susi/Controllers/LoginController/LoginVCMethods.swift
@@ -223,7 +223,7 @@ extension LoginViewController {
                 emailTextField.dividerActiveColor = .green
             }
         } else if textField == passwordTextField, let password = passwordTextField.text {
-            if password.isEmpty || password.count < 5 {
+            if password.isEmpty || password.count < 6 || password.count > 64{
                 passwordTextField.dividerActiveColor = .red
             } else {
                 passwordTextField.dividerActiveColor = .green


### PR DESCRIPTION
Fixes #455 

Changes: Password length limit from login page is removed, as there is no requirement of showing minimum character limit in the login page.

Screenshots for the change: 
GIF:
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/31539812/47963203-c01d0b80-e04e-11e8-857f-7d72cafd8c56.gif)



