### PR TITLE
Last message is completely visible in chat

### DIFF
--- a/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
+++ b/Susi/Controllers/ChatViewController/CollectionViewDelegate.swift
@@ -113,7 +113,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
             } else if message.actionType == ActionType.video_play.rawValue || message.actionType == ActionType.audio_play.rawValue {
                 return CGSize(width: view.frame.width, height: 158)
             }
-            return CGSize(width: view.frame.width, height: estimatedFrame.height + 38)
+            return CGSize(width: view.frame.width, height: estimatedFrame.height + 60)
         }
     }
 


### PR DESCRIPTION
Fixes #457 

Changes: Changed the height of CGSize from 38 to 60. Now, the last message in chat can be seen completely

Screenshots for the change: 
GIF -
![expected](https://user-images.githubusercontent.com/31539812/47987906-bf47b080-e106-11e8-9382-c33e13e5ace1.gif)

.

