### PR TITLE
Fix:Toast notification when feedback text field is empty

### DIFF
--- a/Susi/Controllers/SkillDetailViewController/SkillDetailVCMethods.swift
+++ b/Susi/Controllers/SkillDetailViewController/SkillDetailVCMethods.swift
@@ -319,6 +319,8 @@ extension SkillDetailViewController: UITextFieldDelegate {
         if let delegate = UIApplication.shared.delegate as? AppDelegate, let user = delegate.currentUser {
             if let feedbackText = skillFeedbackTextField.text, feedbackText.count > 0 {
                 self.submitSkillFeedback(for: user.accessToken)
+            } else {
+                view.makeToast("Please enter a feedback to post")
             }
         } else {
             let loginAlertController = UIAlertController(title: "You are not logged-in", message: "Please login to post skill feedback", preferredStyle: .alert)


### PR DESCRIPTION
Fixes #504 

Toast Notification when feedback text field is empty

Screenshots for the change: 

![screenshot 2019-02-03 at 1 46 09 am](https://user-images.githubusercontent.com/32494694/52168916-54823180-2756-11e9-9b06-3b6a064fdcae.png)
