### PR TITLE
Fix: Image Cell Thumbs Up and Down Overlap Issue

### DIFF
--- a/Susi/Custom Views/Message Cells/ImageCell.swift
+++ b/Susi/Custom Views/Message Cells/ImageCell.swift
@@ -171,6 +171,8 @@ class ImageCell: ChatMessageCell {
         thumbUpIcon.removeFromSuperview()
         thumbDownIcon.removeFromSuperview()
         timeLabel.rightAnchor.constraint(equalTo: textBubbleView.rightAnchor, constant: -16).isActive = true
+        thumbDownIcon.isHidden = true
+        thumbUpIcon.isHidden = true
     }
 
 }


### PR DESCRIPTION
Fixes #555 
 This problem is occurring when we try to scroll up or down the chat view.  

Changes: Hide the thumbs-up and thumbs-down Icon after successful feedback

Screenshots for the change: 

![Screenshot 2019-05-02 at 12 10 38 AM](https://user-images.githubusercontent.com/32494694/57035389-86c8ff80-6c6f-11e9-8f29-6dbee099c5e4.png)

